### PR TITLE
Avoids "<class 'ValueError'>: min() arg is an empty sequence" error.

### DIFF
--- a/PyOpticL/laser.py
+++ b/PyOpticL/laser.py
@@ -293,7 +293,8 @@ class beam_path:
                         intersect.append(-(x1-0)/cos(a1))
                     if yf < 0:
                         intersect.append(-(y1-0)/sin(a1))
-                    self.beams.append([x1, y1, a1, min(intersect), beam_index])
+                    if len(intersect) > 0: # sometimes intersect is empty ... skip to avoid ValueError exception
+                        self.beams.append([x1, y1, a1, min(intersect), beam_index])
                 return
             
             if block:

--- a/PyOpticL/laser.py
+++ b/PyOpticL/laser.py
@@ -282,7 +282,8 @@ class beam_path:
                 # restrict beam to baseplate
                 if selfobj.Baseplate.dx != 0 and selfobj.Baseplate.dy != 0:
                     intersect = []
-                    xf, yf = x1+500*cos(a1), y1+500*sin(a1) # TODO find a better way than this
+                    max_len = sqrt(selfobj.Baseplate.dx.Value**2+selfobj.Baseplate.dy.Value**2)
+                    xf, yf = x1+max_len*cos(a1), y1+max_len*sin(a1)
                     x_max = selfobj.Baseplate.dx.Value
                     y_max = selfobj.Baseplate.dy.Value
                     if x_max < xf:
@@ -293,8 +294,7 @@ class beam_path:
                         intersect.append(-(x1-0)/cos(a1))
                     if yf < 0:
                         intersect.append(-(y1-0)/sin(a1))
-                    if len(intersect) > 0: # sometimes intersect is empty ... skip to avoid ValueError exception
-                        self.beams.append([x1, y1, a1, min(intersect), beam_index])
+                    self.beams.append([x1, y1, a1, min(intersect), beam_index])
                 return
             
             if block:


### PR DESCRIPTION
The intersect list in calculate_beam_path() function is sometimes empty. Passing empty list to min() generates exception "<class 'ValueError'>: min() arg is an empty sequence". Check if len(intersect)>0 to avoid such exceptions.  