### PR TITLE
Increase maximum beam index to 1024 and make it configurable.

### DIFF
--- a/PyOpticL/laser.py
+++ b/PyOpticL/laser.py
@@ -4,6 +4,7 @@ from math import *
 import numpy as np
 
 inch = 25.4
+max_beam_index = 1024
 
 def is_mult(x, factor, tol=1e-5):
     return isclose((abs(x)+tol/2)%factor, 0, abs_tol=tol)
@@ -175,7 +176,7 @@ class beam_path:
 
     # compute full beam path given start point and angle
     def calculate_beam_path(self, selfobj, x1, y1, a1, beam_index=1):
-        if beam_index > 200:
+        if beam_index > max_beam_index:
             return
         
         count = 0 # number of interactions per beam

--- a/PyOpticL/layout.py
+++ b/PyOpticL/layout.py
@@ -27,6 +27,13 @@ turn = {"up-right":-45,
         "down-left":135,
         "left-down":-45}
 
+def set_max_beam_index(index):
+    '''
+    Set a maximum beam index. Default is 1024. 
+
+    '''
+    laser.max_beam_index = index
+
 def check_bound(obj1, obj2):
     bound1 = obj1.BoundBox
     bound2 = obj2.BoundBox


### PR DESCRIPTION
Currently the maximum beam index for the beam path calculations is hardcoded as 200 in the calculate_beam_path function, which may not be sufficient for the relatively complex layouts. This patch increases default to 1024 and makes it configurable using layout.set_max_beam_index() function. 